### PR TITLE
Fix pip install error since not included requirements.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include requirements.txt


### PR DESCRIPTION
Hello, Tarek,

I've fixed #1 issues.
It seems like that **flakon-0.1.tar.gz** file was created without `requirements.txt`.
So, I've add the file via `MANIFEST.in`.

Thank you for your book, I like it.