### PR TITLE
Support parsing of methods with parameters

### DIFF
--- a/flakon/blueprints.py
+++ b/flakon/blueprints.py
@@ -56,9 +56,10 @@ class SwaggerBlueprint(JsonBlueprint):
         ops = {}
         for path, spec in self.spec['paths'].items():
             for method, options in spec.items():
-                options['method'] = method.upper()
-                options['path'] = path
-                ops[options['operationId']] = options
+                if method != "parameters":
+                    options['method'] = method.upper()
+                    options['path'] = path
+                    ops[options['operationId']] = options
         return ops
 
     def operation(self, operation_id, **options):


### PR DESCRIPTION
Suppose I have a yaml containing something like this:
```yaml
...
paths:
  "/users/{id}":
    parameters:
    - in: path
      name: id
      description: The user identifier
      required: true
      type: integer
    get:
      operationId: getUserById
      summary: Return the user specified by its identifier
      responses:
        '200':
          description: The requested user
          schema:
            "$ref": "#/definitions/User"
        '400':
          description: Bad Request
        '401':
          description: Unauthorized
        '403':
          description: Forbidden
...
```
Since in the `blueprints.py` the code is looping though all methds, it finds also the *parameters* property at the same depth of *get*, and it gets included in *ops* object, casuing the model validation to fail running *pytest*.